### PR TITLE
Added primary column, default:false, to users table (to allow post au…

### DIFF
--- a/db/migrate/20170711161702_add_primary_to_users.rb
+++ b/db/migrate/20170711161702_add_primary_to_users.rb
@@ -1,0 +1,5 @@
+class AddPrimaryToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :primary, :boolean
+  end
+end

--- a/db/migrate/20170711162717_add_default_value_to_primary.rb
+++ b/db/migrate/20170711162717_add_default_value_to_primary.rb
@@ -1,0 +1,5 @@
+class AddDefaultValueToPrimary < ActiveRecord::Migration
+  def change
+    change_column :users, :primary, :boolean, default: false
+  end
+end

--- a/db/migrate/20170711192310_change_column_name_users_primary.rb
+++ b/db/migrate/20170711192310_change_column_name_users_primary.rb
@@ -1,0 +1,5 @@
+class ChangeColumnNameUsersPrimary < ActiveRecord::Migration
+  def change
+    rename_column :users, :primary, :accepted
+  end
+end

--- a/db/migrate/20170711193304_remove_accepted_from_users.rb
+++ b/db/migrate/20170711193304_remove_accepted_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveAcceptedFromUsers < ActiveRecord::Migration
+  def change
+    remove_column :users, :accepted, :boolean
+  end
+end

--- a/db/migrate/20170711193959_add_column_to_answers.rb
+++ b/db/migrate/20170711193959_add_column_to_answers.rb
@@ -1,0 +1,5 @@
+class AddColumnToAnswers < ActiveRecord::Migration
+  def change
+    add_column :answers, :accepted, :boolean
+  end
+end

--- a/db/migrate/20170711194200_change_default_answers_accepted.rb
+++ b/db/migrate/20170711194200_change_default_answers_accepted.rb
@@ -1,0 +1,5 @@
+class ChangeDefaultAnswersAccepted < ActiveRecord::Migration
+  def change
+    change_column_default :answers, :accepted, true
+  end
+end

--- a/db/migrate/20170711194553_change_default_answers_accepted_to_false.rb
+++ b/db/migrate/20170711194553_change_default_answers_accepted_to_false.rb
@@ -1,0 +1,5 @@
+class ChangeDefaultAnswersAcceptedToFalse < ActiveRecord::Migration
+  def change
+    change_column_default :answers, :accepted, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170711162717) do
+ActiveRecord::Schema.define(version: 20170711194553) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,8 +20,9 @@ ActiveRecord::Schema.define(version: 20170711162717) do
     t.text     "response"
     t.integer  "user_id"
     t.integer  "question_id"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
+    t.boolean  "accepted",    default: false
   end
 
   add_index "answers", ["user_id"], name: "index_answers_on_user_id", using: :btree
@@ -41,9 +42,8 @@ ActiveRecord::Schema.define(version: 20170711162717) do
     t.string   "last_name"
     t.string   "email"
     t.boolean  "active"
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
-    t.boolean  "primary",    default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   add_foreign_key "answers", "questions"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170628194008) do
+ActiveRecord::Schema.define(version: 20170711162717) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,8 +41,9 @@ ActiveRecord::Schema.define(version: 20170628194008) do
     t.string   "last_name"
     t.string   "email"
     t.boolean  "active"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.boolean  "primary",    default: false
   end
 
   add_foreign_key "answers", "questions"


### PR DESCRIPTION
…thor to select as the main answer) 

Not a big change, but we need a way to allow users to mark a question as answered. I figured the easiest way was to have a boolean setting called "primary" on each answer. If a user marks an answer as primary, the view shows the question as "answered and prints the primary answer at the top of any previews, etc.

Thoughts?