### PR TITLE
Move oauth creds

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A Q&A Forum for Instacart Employees
 - [ ] Fix Auth-Model Specs
 - [ ] Tag Cloud Functionality
 - [ ] Refactor Questions Controller for #new and #create to use lazy execution
-- [ ] move `current_user` to application controller
+- [x] move `current_user` to application controller
 - [ ] `set_question` changes:
     - [ ] include find, new, not found, multiple
     - [ ] inlcude assigning `question.user`  

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,7 +1,7 @@
 OmniAuth.config.logger = Rails.logger
 
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :google_oauth2, ENV['INSTASMART_GAUTH_CLIENT_ID'], ENV['INSTASMART_GAUTH_CLIENT_SECRET'],
+  provider :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"],
     {
       client_options:
       {ssl:


### PR DESCRIPTION
Moved oauth creds to a .yml file that's part of git ignore. will allow us to deploy the app on a server. Right now, the creds are stored locally.