### PR TITLE
Show page reduction

### DIFF
--- a/client/app/bundles/src/components/answers/AllAnswers.jsx
+++ b/client/app/bundles/src/components/answers/AllAnswers.jsx
@@ -57,8 +57,7 @@ class AllAnswers extends React.Component {
     });
 
     return (
-      <div className="card-block mt-5 all-answers">
-        <h3>Answers ({this.props.answers.length}) </h3> 
+      <div className="card-block mt-2 all-answers">
         {answersListing}
       </div>
     );

--- a/client/app/bundles/src/components/comments/AllComments.jsx
+++ b/client/app/bundles/src/components/comments/AllComments.jsx
@@ -16,7 +16,6 @@ const AllComments = props => {
 
   return(
     <div className="card-block mx-5">
-      <h5 className="mt-2">Comments ({props.comments.length})</h5>
       {commentsListing}
     </div>
   );

--- a/client/app/bundles/src/components/questions/show_questions/QuestionAuthor.jsx
+++ b/client/app/bundles/src/components/questions/show_questions/QuestionAuthor.jsx
@@ -10,8 +10,8 @@ const QuestionAuthor = props => {
   return (
     <div>
       <div className="question-author-container row">
-        <div className="col-md-4 offset-md-8">
-          {image} <small><i>Asked {props.question.created_at} ago by {userInfo}</i></small> 
+        <div className="col-md-5 offset-md-7">
+            {image} <small><i>Asked {props.question.created_at} ago by {userInfo}</i></small> 
         </div>
       </div>
     </div>

--- a/client/app/bundles/src/components/questions/show_questions/QuestionAuthor.jsx
+++ b/client/app/bundles/src/components/questions/show_questions/QuestionAuthor.jsx
@@ -9,15 +9,9 @@ const QuestionAuthor = props => {
 
   return (
     <div>
-      <div className="question-author-container">
-        <div>
-          {image}
-        </div>
-        <div>
-          {userInfo}
-        </div>
-        <div>
-          <small><i>Asked {props.question.created_at} ago</i></small>
+      <div className="question-author-container row">
+        <div className="col-md-4 offset-md-8">
+          {image} <small><i>Asked {props.question.created_at} ago by {userInfo}</i></small> 
         </div>
       </div>
     </div>

--- a/client/app/bundles/src/components/questions/show_questions/QuestionAuthor.jsx
+++ b/client/app/bundles/src/components/questions/show_questions/QuestionAuthor.jsx
@@ -10,7 +10,7 @@ const QuestionAuthor = props => {
   return (
     <div>
       <div className="question-author-container row">
-        <div className="col-md-5 offset-md-7">
+        <div className="col-lg-5 offset-lg-7">
             {image} <small><i>Asked {props.question.created_at} ago by {userInfo}</i></small> 
         </div>
       </div>

--- a/client/app/bundles/src/components/questions/show_questions/QuestionDetail.jsx
+++ b/client/app/bundles/src/components/questions/show_questions/QuestionDetail.jsx
@@ -103,8 +103,8 @@ class QuestionDetail extends React.Component {
         onSubmit={this.onSubmitEditQuestion}/>) : null;
 
     return (
-      <div className="row pt-1 pl-1 mr-0 show-question-detail">
-        <div className="card-block question-summary col-md-12 pb-2 ml-2">
+      <div className="show-question-detail">
+        <div className="question-summary col-md-12 pb-2 ml-2">
           {questionDetails}
 
           {questionForm}

--- a/client/app/bundles/src/components/questions/show_questions/ShowQuestionContainer.jsx
+++ b/client/app/bundles/src/components/questions/show_questions/ShowQuestionContainer.jsx
@@ -184,10 +184,10 @@ class ShowQuestionConatiner extends React.Component {
     return (
       <div>
         <FixedNav includeSort={false}/>
-        <div className="show-question-top-container">
+        <div className="show-question-top-container card mt-5">
           <ScrollToTopOnMount />
-          <div className="row">
-            <div className="col-md-10 show-question pr-0">
+          <div className="container py-3 px-0">
+            <div className="show-question">
               {showQuestion}
               <ReactCSSTransitionGroup
                 transitionName="form-transition"
@@ -197,13 +197,6 @@ class ShowQuestionConatiner extends React.Component {
               </ReactCSSTransitionGroup>
               {tabs}
               {tabContent}
-            </div>
-            <div id= "author-info" className="col-md-2 stat-tags-col">
-              <div className="pt-2">
-                {author}
-                <hr />
-                {tags}
-              </div>
             </div>
           </div>
         </div>

--- a/client/app/bundles/src/components/questions/show_questions/ShowQuestionContainer.jsx
+++ b/client/app/bundles/src/components/questions/show_questions/ShowQuestionContainer.jsx
@@ -188,7 +188,9 @@ class ShowQuestionConatiner extends React.Component {
           <ScrollToTopOnMount />
           <div className="container py-3 px-0">
             <div className="show-question">
+              {author}
               {showQuestion}
+              {tags}
               <ReactCSSTransitionGroup
                 transitionName="form-transition"
                 transitionEnterTimeout={300}

--- a/client/app/bundles/src/components/questions/show_questions/ShowQuestionContainer.jsx
+++ b/client/app/bundles/src/components/questions/show_questions/ShowQuestionContainer.jsx
@@ -184,21 +184,31 @@ class ShowQuestionConatiner extends React.Component {
     return (
       <div>
         <FixedNav includeSort={false}/>
-        <div className="show-question-top-container card mt-5">
-          <ScrollToTopOnMount />
-          <div className="container py-3 px-0">
-            <div className="show-question">
-              {author}
-              {showQuestion}
-              {tags}
-              <ReactCSSTransitionGroup
-                transitionName="form-transition"
-                transitionEnterTimeout={300}
-                transitionLeaveTimeout={200}>
-                {showForm}
-              </ReactCSSTransitionGroup>
-              {tabs}
-              {tabContent}
+        <div className="container">
+          <div className="show-question-top-container card mt-5">
+            <ScrollToTopOnMount />
+            <div className="container py-3 px-0">
+              <div className="show-question">
+                <div className="card-block">
+                  {author}
+                </div>
+                <div className="card-text">
+                  {tags}
+                </div>
+                <div className="card-block">
+                  {showQuestion}
+                </div>
+                <ReactCSSTransitionGroup
+                  transitionName="form-transition"
+                  transitionEnterTimeout={300}
+                  transitionLeaveTimeout={200}>
+                  {showForm}
+                </ReactCSSTransitionGroup>
+                <div className="card-block">
+                  {tabs}
+                  {tabContent}
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/client/app/bundles/src/components/tags/IndexQuestionTags.jsx
+++ b/client/app/bundles/src/components/tags/IndexQuestionTags.jsx
@@ -12,7 +12,7 @@ const QuestionIndexTags = props => {
 
   return (
     <div className={`row pl-3 ${addClass}`}>
-      {tags}
+        {tags}
     </div>
   );
 };

--- a/client/app/bundles/src/stylesheets/comments_answers.scss
+++ b/client/app/bundles/src/stylesheets/comments_answers.scss
@@ -44,3 +44,7 @@
 .top-answer-star{
   color: lightgrey;
 }
+
+#add-answer-comment {
+  color: red;
+}


### PR DESCRIPTION
Some bits:

+ I need to make sure the author information stays to the right and doesn't wrap (still working on it)
+ I think we should shrink the profile image thumbnail. It seems a bit "extra"
+ I really want tags to live between the question.body and the answer/comment/like buttons, but the show question component encompasses all of those. @logtheman How difficult is it to add the tags into that component proper (wouldn't mind you showing me how at lunch if it's not a big change) I tried putting them above the tags, but that looks weird too.

![screen shot 2017-08-28 at 8 50 17 am](https://user-images.githubusercontent.com/16847094/29781516-49f1cfc0-8bce-11e7-8697-4b9bd4515469.png)
